### PR TITLE
fix bug about single quotes transform

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -11,3 +11,7 @@ Release v0.1.0
 ### v0.1.2
 
 - fixed `<style>` tag bug;
+
+### v0.1.3
+
+- make single quote encode configurable

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ require.loadCSS = function(config) {
 ```javascript
 {
     debug              : false,            // Debug mode
+    transSingle        : true,             // Trans single quote to '&#39;'
     amd                : false,            // AMD style, Define module name and deps
     define             : true,             // Using define() wrapper the module, false for Node.js (CommonJS style)
     defineName         : false,            // Define the module name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gulp-vue-module",
+  "name": "gulp-vue-module-microdreams",
   "version": "0.1.3",
-  "homepage": "https://github.com/Pandao/gulp-vue-module-microdreams",
+  "homepage": "https://github.com/geektheripper/gulp-vue-module",
   "description": "Gulp plugin for Vue.js `*.vue` component file complie to AMD / CMD / CommonJS module.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-vue-module",
   "version": "0.1.3",
-  "homepage": "https://github.com/pandao/gulp-vue-module",
+  "homepage": "https://github.com/Pandao/gulp-vue-module-microdreams",
   "description": "Gulp plugin for Vue.js `*.vue` component file complie to AMD / CMD / CommonJS module.",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/pandao/gulp-vue-module.git"
+    "url": "git://github.com/geektheripper/gulp-vue-module.git"
   },
   "author": "Pandao",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-vue-module",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/pandao/gulp-vue-module",
   "description": "Gulp plugin for Vue.js `*.vue` component file complie to AMD / CMD / CommonJS module.",
   "main": "index.js",


### PR DESCRIPTION
use `replace(/('|\\)/g, '\\$1').replace(/\r/g, '\\r').replace(/\n/g, '\\n')` to transform html string
