### PR TITLE
added externalRequire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ $color:red;
     });
 </script>
 ```
+>You can set `externalRequire` to true and inject `vue` into the file insted of requiring it internally
 
 > `<template>` tag unsupport set lang attribute, support set `include="/path/to/xxx.xxx"` attribute.
 > 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ module.exports = function(options) {
         indent             : '    ',              // Indent whitespace
         headerComment      : true,                // Using <header-comment> Insert the header comments
         templateReplaceTag : '__template__', // vue component template replace tag
-        loadCSSMethod      : 'require.loadCSS'    // define the load css method for require
+        loadCSSMethod      : 'require.loadCSS',    // define the load css method for require
+        externalRequire      : false            // don't pass require as a parameter
     };
 
     var settings = Object.assign({}, defaults, options),
@@ -207,8 +208,14 @@ module.exports = function(options) {
             }
             
             if (settings.define) {
-                moduleContent = 'define(' + defineName + deps + 'function(require, exports, module) {\n' + loadCSS + script+'\n});';
-            } else {
+                if(settings.externalRequire){
+                    moduleContent = 'define(' + defineName + deps + 'function('+ moduleDeps +') {\n' + loadCSS + script+'\n});';
+                }
+                else {
+                    moduleContent = 'define(' + defineName + deps + 'function(require, exports, module) {\n' + loadCSS + script+'\n});';
+                }
+            } 
+            else {
                 moduleContent = script;
             }
 


### PR DESCRIPTION
This works better with our existing requirejs setup. Allows us to output files like so;
mycomponent.js
`define(["vue", "vuex", "model"], function(vue,vuex,model) {`
We define our require config in a single file with paths like this;
```
require.config({
  paths: {
    vue: ['/common/components/vue-2.4.4/vue'],
    vuex: ['/common/components/vue-2.4.4/vuex-2.4.1'],
    model: ['/app/scripts/model/model'], 
    mycomponent: ['/app/scripts/vue/output/mycomponent.js']
```