### PR TITLE
Update node-sass for Windows 64 bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "node-sass": "^3.4.2",
+    "node-sass": "^4.7.2",
     "parse5": "^2.1.5",
     "through2": "^2.0.1"
   }


### PR DESCRIPTION
Windows 64bit needs a more recent version of node-sass